### PR TITLE
Removing suprious print listing all library keys

### DIFF
--- a/plexInfluxdbCollector.py
+++ b/plexInfluxdbCollector.py
@@ -361,7 +361,6 @@ class plexInfluxdbCollector():
             host_libs = []
             if len(libs) > 0:
                 lib_keys = [lib.attrib['key'] for lib in libs]  # TODO probably should catch exception here
-                print(','.join(lib_keys))
                 self.send_log('Scanning libraries on server {} with keys {}'.format(server, ','.join(lib_keys)), 'info')
                 for key in lib_keys:
                     req_uri = 'http://{}:32400/library/sections/{}/all'.format(server, key)


### PR DESCRIPTION
Removing the print for library keys, as this is handled by the info logger the line after (and this contradicts the line 456 (no futher output)