### PR TITLE
Implement InfluxDB username and password and make logging optional

### DIFF
--- a/plexInfluxdbCollector.py
+++ b/plexInfluxdbCollector.py
@@ -31,6 +31,8 @@ class plexInfluxdbCollector():
         self.influx_client = InfluxDBClient(
             self.config.influx_address,
             self.config.influx_port,
+            username=self.config.influx_username,
+            password=self.config.influx_password,
             database=self.config.influx_database,
             ssl=self.config.influx_ssl,
             verify_ssl=self.config.influx_verify_ssl
@@ -489,6 +491,8 @@ class configManager():
         self.influx_address = self.config['INFLUXDB']['Address']
         self.influx_port = self.config['INFLUXDB'].getint('Port', fallback=8086)
         self.influx_database = self.config['INFLUXDB'].get('Database', fallback='plex_data')
+        self.influx_username = self.config['INFLUXDB'].get('Username', fallback='root')
+        self.influx_password = self.config['INFLUXDB'].get('Password', fallback='root')
         self.influx_ssl = self.config['INFLUXDB'].getboolean('SSL', fallback=False)
         self.influx_verify_ssl = self.config['INFLUXDB'].getboolean('Verify_SSL', fallback=True)
 

--- a/plexInfluxdbCollector.py
+++ b/plexInfluxdbCollector.py
@@ -475,7 +475,8 @@ class configManager():
 
         self._load_config_values()
         self._validate_plex_servers()
-        self._validate_logging_level()
+        if self.logging:
+            self._validate_logging_level()
         print('Configuration Successfully Loaded')
 
     def _load_config_values(self):
@@ -498,9 +499,10 @@ class configManager():
 
         #Logging
         self.logging = self.config['LOGGING'].getboolean('Enable', fallback=False)
-        self.logging_level = self.config['LOGGING']['Level'].lower()
-        self.logging_file = self.config['LOGGING']['LogFile']
-        self.logging_censor = self.config['LOGGING'].getboolean('CensorLogs', fallback=True)
+        if self.logging:
+            self.logging_level = self.config['LOGGING']['Level'].lower()
+            self.logging_file = self.config['LOGGING']['LogFile']
+            self.logging_censor = self.config['LOGGING'].getboolean('CensorLogs', fallback=True)
 
         if servers:
             self.plex_servers = self.config['PLEX']['Servers'].replace(' ', '').split(',')


### PR DESCRIPTION
### Only load and validate logging settings if enabled
If logging is set to `False` there shouldn't be any requirement for the rest of the configuration settings for logging.

### Implement InfluxDB username and password
`Username` and `Password` configuration items are shown in the example config. But they aren't implemented, this adds them.