### PR TITLE
New configs for Plex libraries names

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Enter your desired information in config.ini and run plexcollector.py
 |Database       |Database to write collected stats to                                                                                |
 |Username       |User that has access to the database                                                                                |
 |Password       |Password for above user                                                                                             |
-|Verify_SSL     |Disable SSL verification for InfluxDB Connection                                                                                             |
+|Verify_SSL     |Disable SSL verification for InfluxDB Connection                                                                    |
 #### PLEX
 |Key            |Description                                                                                                         |
 |:--------------|:-------------------------------------------------------------------------------------------------------------------|
@@ -34,7 +34,13 @@ Enter your desired information in config.ini and run plexcollector.py
 |Password       |Plex Password                                                                                                       |
 |Servers        |A comma separated list of servers you wish to pull data from.                                                       |
 |HTTPS          |Connect to server using HTTPS                                                                                       |
-|Verify_SSL        |Disable SSL verification (Use this if you have a self sign SSL)                                                     |
+|Verify_SSL     |Disable SSL verification (Use this if you have a self sign SSL)                                                     |
+#### PLEX_NAMES
+|Key            |Description                                                                                                         |
+|:--------------|:-------------------------------------------------------------------------------------------------------------------|
+|Movies         |Plex Movies library name                                                                                            |
+|TV             |Plex TV Shows library name                                                                                          |
+|Music          |Plex Music library name                                                                                             |
 #### LOGGING
 |Key            |Description                                                                                                         |
 |:--------------|:-------------------------------------------------------------------------------------------------------------------|

--- a/config.ini
+++ b/config.ini
@@ -22,6 +22,11 @@ Servers =
 HTTPS = False
 Verify_SSL = False
 
+[PLEX_NAMES]
+Movies=Movies
+TV=TV Shows
+Music=Music
+
 [LOGGING]
 # Valid Options: critical, error, warning, info, debug
 Level = error

--- a/plexcollector/PlexInfluxdbCollector.py
+++ b/plexcollector/PlexInfluxdbCollector.py
@@ -313,9 +313,9 @@ class PlexInfluxdbCollector:
 
         for server in self.plex_servers:
             recent_list = []
-            recent_list += server.library.section('Music').search(sort='addedAt:desc', libtype='track', maxresults=10)
-            recent_list += server.library.section('TV Shows').search(sort='addedAt:desc', libtype='episode', maxresults=10)
-            recent_list += server.library.section('Movies').search(sort='addedAt:desc', maxresults=10)
+            recent_list += server.library.section(config.plex_music_name).search(sort='addedAt:desc', libtype='track', maxresults=10)
+            recent_list += server.library.section(config.plex_tv_name).search(sort='addedAt:desc', libtype='episode', maxresults=10)
+            recent_list += server.library.section(config.plex_movies_name).search(sort='addedAt:desc', maxresults=10)
 
             for item in recent_list:
                 data = {

--- a/plexcollector/config/configmanager.py
+++ b/plexcollector/config/configmanager.py
@@ -46,6 +46,11 @@ class ConfigManager:
         self.plex_verify_ssl = self.config['PLEX'].getboolean('Verify_SSL', fallback=False)
         servers = len(self.config['PLEX']['Servers'])
 
+        # Plex Names
+        self.plex_movies_name = self.config['PLEX_NAMES']['Movies']
+        self.plex_tv_name = self.config['PLEX_NAMES']['TV']
+        self.plex_music_name = self.config['PLEX_NAMES']['Music']
+
         #Logging
         self.logging_level = self.config['LOGGING']['Level'].upper()
 


### PR DESCRIPTION
If names differ from english in Plex lib names, the script does not work.
It allows libraries names configuration directly in `config.ini` instead of patching the code manually.